### PR TITLE
Return TimeoutId from networkIdleCallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function cancelNetworkIdleCallback(callbackId) {
   clearTimeout(callbackId)
 
   networkIdleCallback.__callbacks__ = networkIdleCallback.__callbacks__
-    .filter(cb => cb.id === callbackId)
+    .filter(cb => cb.id !== callbackId)
 }
 
 networkIdleCallback.__popCallback__ = (callback, didTimeout) => {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function cancelNetworkIdleCallback(callbackId) {
   clearTimeout(callbackId)
 
   networkIdleCallback.__callbacks__ = networkIdleCallback.__callbacks__
-    .find(cb => cb.id === callbackId)
+    .filter(cb => cb.id === callbackId)
 }
 
 networkIdleCallback.__popCallback__ = (callback, didTimeout) => {

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ function networkIdleCallback(fn, options = { timeout: 0 }) {
 
   messageChannel.port1.addEventListener('message', handleMessage);
   messageChannel.port1.start();
+  
+  return timeoutId;
 }
 
 function cancelNetworkIdleCallback(callbackId) {


### PR DESCRIPTION
According to the docs. We should be able to do the following:
```javascript
import { networkIdleCallback, cancelNetworkCallback } from 'network-idle-callback'

const id = networkIdleCallback(() => {
  console.log('Execute low network priority tasks here.')
}, { timeout: 1000 })

// Cancel the callback
cancelNetworkCallback(id)
```

But in order for this to be possible. `networkIdleCallback` needs to return something. Let's return someting!